### PR TITLE
Get engineering-leads out of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @planningcenter/engineering-leads
+* @bensie


### PR DESCRIPTION
We are transitioning the ownership of things that were previously owned by Engineering Leads. I looked at the [commit history](https://github.com/planningcenter/maybe_so/graphs/commit-activity) of this repo and the majority of commits are by @bensie so I'm making them the owner.